### PR TITLE
fix for usa kia charge status detection

### DIFF
--- a/src/lib/bluelink-regions/usa-kia.ts
+++ b/src/lib/bluelink-regions/usa-kia.ts
@@ -172,13 +172,20 @@ export class BluelinkUSAKia extends Bluelink {
       }
     }
 
+    let chargingPower = 0
+    let isCharging = false
+
+    if (status.evStatus.batteryCharge) {
+      isCharging = true
+      chargingPower = status.evStatus.realTimePower
+    }
+
     return {
       lastStatusCheck: Date.now(),
       lastRemoteStatusCheck: lastRemoteCheck.getTime(),
-      isCharging: status.evStatus.batteryCharge,
+      isCharging: isCharging,
       isPluggedIn: status.evStatus.pluggedInState > 0 ? true : false,
-      chargingPower:
-        status.evStatus.pluggedInState > 0 && status.evStatus.batteryCharge ? status.evStatus.realTimePower : 0,
+      chargingPower: chargingPower,
       remainingChargeTimeMins: status.evStatus.remainChargeTime[0].timeInterval.value,
       // sometimes range back as zero? if so ignore and use cache
       range:


### PR DESCRIPTION
Not sure if this is isolated to myself and I have only validated this for "slow charging", however, I found that there wasn't a `pluggedInState` property in the `vehicleStatusRpt` dictionary. I changed to use the `batteryCharge` property instead. Sorry if I missed any contributors guidelines.