### PR TITLE
Added "WalkawayLock" Function

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -495,24 +495,38 @@ const pageIcons = connect(
             if (isUpdating) {
               return
             }
-            quickOptions(['Lock', 'Unlock', 'Cancel'], {
+            quickOptions(['Lock', 'WalkawayLock', 'Unlock', 'Cancel'], {
               title: 'Confirm lock action',
               onOptionSelect: (opt) => {
                 if (opt === 'Cancel') return
+                const command = opt === 'Lock' ? 'lock' : opt === 'WalkawayLock' ? 'walkawayLock' : 'unlock'
+                const updatingText =
+                  opt === 'Lock'
+                    ? 'Locking car ...'
+                    : opt === 'WalkawayLock'
+                      ? 'WalkawayLock (waiting for doors closed) ...'
+                      : 'Unlocking car ...'
+                const successText = opt === 'Lock' || opt === 'WalkawayLock' ? 'Car locked!' : 'Car unlocked!'
+                const failureText =
+                  opt === 'Lock'
+                    ? 'Failed to lock car!!!'
+                    : opt === 'WalkawayLock'
+                      ? 'WalkawayLock failed!!!'
+                      : 'Failed to unlock car!!!'
                 doAsyncUpdate({
-                  command: opt === 'Lock' ? 'lock' : 'unlock',
+                  command,
                   bl: bl,
                   actions: updatingActions,
                   actionKey: 'lock',
-                  updatingText: opt === 'Lock' ? 'Locking car ...' : 'Unlocking car ...',
-                  successText: opt === 'Lock' ? 'Car locked!' : 'Car unlocked!',
-                  failureText: `Failed to ${opt === 'Lock' ? 'lock' : 'unlock'} car!!!`,
+                  updatingText,
+                  successText,
+                  failureText,
                   successCallback: (data) => {
                     updateStatus({
                       ...bl.getCachedStatus(),
                       status: {
                         ...data,
-                        locked: opt === 'Lock' ? true : false,
+                        locked: opt === 'Lock' || opt === 'WalkawayLock' ? true : false,
                       },
                     } as Status)
                   },

--- a/src/lib/bluelink-regions/australia.ts
+++ b/src/lib/bluelink-regions/australia.ts
@@ -398,6 +398,11 @@ export class BluelinkAustralia extends Bluelink {
         Boolean(status.Cabin.Door.Row2.Driver.Open) &&
         Boolean(status.Cabin.Door.Row2.Passenger.Open)
       ),
+      doorOpen:
+        Boolean(status.Cabin.Door.Row1.Driver.Open) ||
+        Boolean(status.Cabin.Door.Row1.Passenger.Open) ||
+        Boolean(status.Cabin.Door.Row2.Driver.Open) ||
+        Boolean(status.Cabin.Door.Row2.Passenger.Open),
       climate: Boolean(status.Cabin.HVAC.Row1.Driver.Blower.SpeedLevel > 0),
       soc: status.Green.BatteryManagement.BatteryRemain.Ratio,
       twelveSoc: status.Electronics.Battery.Level ? status.Electronics.Battery.Level : 0,

--- a/src/lib/bluelink-regions/base.ts
+++ b/src/lib/bluelink-regions/base.ts
@@ -46,6 +46,7 @@ export interface BluelinkStatus {
   remainingChargeTimeMins: number
   range: number
   locked: boolean
+  doorOpen: boolean
   climate: boolean
   soc: number
   twelveSoc: number
@@ -300,6 +301,18 @@ export class Bluelink {
       range: this.cache ? this.cache.status.range : 0,
       soc: this.cache ? this.cache.status.soc : 0,
       locked: status.doorLock,
+      doorOpen: (() => {
+        const d = status?.doorOpen
+        if (!d) return this.cache ? this.cache.status.doorOpen : false
+        return (
+          d.frontLeft !== 0 ||
+          d.frontRight !== 0 ||
+          d.backLeft !== 0 ||
+          d.backRight !== 0 ||
+          !!status.trunkOpen ||
+          !!status.hoodOpen
+        )
+      })(),
       climate: status.airCtrlOn,
       twelveSoc: status.battery && status.battery.batSoc ? status.battery.batSoc : 0,
       odometer: odometer ? odometer : this.cache ? this.cache.status.odometer : 0,
@@ -361,6 +374,52 @@ export class Bluelink {
     }
   }
 
+  /**
+   * Waits 10 seconds, then polls vehicle status every 10 seconds. When doors are closed and unlocked,
+   * sends a lock command. If a 30 second timeout is reached before that condition is met, sends lock anyway.
+   * Walkaway Lock.
+   */
+  public async walkawayLock(): Promise<{ isSuccess: boolean; data: BluelinkStatus }> {
+    const id = this.cache.car.id
+    const pollIntervalMs = 10_000
+    const timeoutMs = 60_000 // 60 seconds
+    const start = Date.now()
+    this.logger.log(`[Walkaway Lock] Starting: poll every ${pollIntervalMs / 1000}s, timeout ${timeoutMs / 1000}s`)
+    await this.sleep(pollIntervalMs)
+    for (;;) {
+      const elapsed = Math.round((Date.now() - start) / 1000)
+      let status: BluelinkStatus
+      try {
+        const res = await this.getStatus(true, true)
+        status = res.status
+      } catch (err) {
+        this.logger.log(`[Walkaway Lock] getStatus failed at ${elapsed}s: ${err}`)
+        throw err
+      }
+      this.logger.log(
+        `[Walkaway Lock] Poll at ${elapsed}s: locked=${status.locked}, doorOpen=${status.doorOpen}, climate=${status.climate}, range=${status.range}, soc=${status.soc}`,
+      )
+      if (status.locked) {
+        this.logger.log(`[Walkaway Lock] Already locked, done (success)`)
+        return { isSuccess: true, data: status }
+      }
+      const timedOut = Date.now() - start >= timeoutMs
+      if (!status.doorOpen || timedOut) {
+        const reason = timedOut ? 'timeout' : 'doors closed'
+        this.logger.log(`[Walkaway Lock] Sending lock (${reason})`)
+        const result = await this.lock(id)
+        if (result.isSuccess) {
+          this.logger.log(`[Walkaway Lock] Lock command succeeded`)
+        } else {
+          this.logger.log(`[Walkaway Lock] Lock command failed: isSuccess=false, data=${JSON.stringify(result.data)}`)
+        }
+        return result
+      }
+      this.logger.log(`[Walkaway Lock] Doors still open, waiting ${pollIntervalMs / 1000}s`)
+      await this.sleep(pollIntervalMs)
+    }
+  }
+
   public async processRequest(
     type: string,
     input: any,
@@ -378,6 +437,9 @@ export class Bluelink {
         break
       case 'lock':
         promise = this.lock(this.cache.car.id)
+        break
+      case 'walkawayLock':
+        promise = this.walkawayLock()
         break
       case 'unlock':
         promise = this.unlock(this.cache.car.id)

--- a/src/lib/bluelink-regions/canada.ts
+++ b/src/lib/bluelink-regions/canada.ts
@@ -267,6 +267,18 @@ export class BluelinkCanada extends Bluelink {
             ? this.cache.status.range
             : 0,
       locked: status.doorLock,
+      doorOpen: (() => {
+        const d = status?.doorOpen
+        if (!d) return this.cache ? this.cache.status.doorOpen : false
+        return (
+          d.frontLeft !== 0 ||
+          d.frontRight !== 0 ||
+          d.backLeft !== 0 ||
+          d.backRight !== 0 ||
+          !!status.trunkOpen ||
+          !!status.hoodOpen
+        )
+      })(),
       climate: status.airCtrlOn,
       soc: status.evStatus.batteryStatus,
       twelveSoc: status.battery && status.battery.batSoc ? status.battery.batSoc : 0,

--- a/src/lib/bluelink-regions/europe.ts
+++ b/src/lib/bluelink-regions/europe.ts
@@ -815,6 +815,11 @@ export class BluelinkEurope extends Bluelink {
         Boolean(status.Cabin.Door.Row2.Driver.Open) &&
         Boolean(status.Cabin.Door.Row2.Passenger.Open)
       ),
+      doorOpen:
+        Boolean(status.Cabin.Door.Row1.Driver.Open) ||
+        Boolean(status.Cabin.Door.Row1.Passenger.Open) ||
+        Boolean(status.Cabin.Door.Row2.Driver.Open) ||
+        Boolean(status.Cabin.Door.Row2.Passenger.Open),
       climate: Boolean(status.Cabin.HVAC.Row1.Driver.Blower.SpeedLevel > 0),
       soc: status.Green.BatteryManagement.BatteryRemain.Ratio,
       twelveSoc: status.Electronics.Battery.Level ? status.Electronics.Battery.Level : 0,

--- a/src/lib/bluelink-regions/india.ts
+++ b/src/lib/bluelink-regions/india.ts
@@ -408,6 +408,7 @@ export class BluelinkIndia extends Bluelink {
             ? this.cache.status.range
             : 0,
       locked: status.doorLock,
+      doorOpen: this.cache?.status?.doorOpen ?? false,
       climate: status.airCtrlOn,
       soc: status.evStatus.batteryStatus,
       twelveSoc: 0, //see if this is reported and fix later

--- a/src/lib/bluelink-regions/mock.ts
+++ b/src/lib/bluelink-regions/mock.ts
@@ -36,6 +36,7 @@ export function returnMockedCarStatus(): BluelinkStatus {
     range: 200,
     soc: 80,
     locked: true,
+    doorOpen: false,
     climate: false,
     twelveSoc: 90,
     odometer: 10000,

--- a/src/lib/bluelink-regions/usa-kia.ts
+++ b/src/lib/bluelink-regions/usa-kia.ts
@@ -350,6 +350,18 @@ export class BluelinkUSAKia extends Bluelink {
             ? this.cache.status.range
             : 0,
       locked: status.doorLock,
+      doorOpen: (() => {
+        const d = status?.doorOpen
+        if (!d) return this.cache ? this.cache.status.doorOpen : false
+        return (
+          d.frontLeft !== 0 ||
+          d.frontRight !== 0 ||
+          d.backLeft !== 0 ||
+          d.backRight !== 0 ||
+          !!status.trunkOpen ||
+          !!status.hoodOpen
+        )
+      })(),
       climate: status.climate.airCtrl,
       soc: status.evStatus.batteryStatus,
       twelveSoc: status.batteryStatus.stateOfCharge ? status.batteryStatus.stateOfCharge : 0,

--- a/src/lib/bluelink-regions/usa.ts
+++ b/src/lib/bluelink-regions/usa.ts
@@ -235,6 +235,18 @@ export class BluelinkUSA extends Bluelink {
             ? this.cache.status.range
             : 0,
       locked: status.doorLock,
+      doorOpen: (() => {
+        const d = status?.doorOpen
+        if (!d) return this.cache ? this.cache.status.doorOpen : false
+        return (
+          d.frontLeft !== 0 ||
+          d.frontRight !== 0 ||
+          d.backLeft !== 0 ||
+          d.backRight !== 0 ||
+          !!status.trunkOpen ||
+          !!status.hoodOpen
+        )
+      })(),
       climate: status.airCtrlOn,
       soc: status.evStatus.batteryStatus,
       twelveSoc: status.battery && status.battery.batSoc ? status.battery.batSoc : 0,

--- a/src/siri.ts
+++ b/src/siri.ts
@@ -46,11 +46,13 @@ export async function processSiriRequest(config: Config, bl: Bluelink, shortcutP
     }
 
     if (found) {
+      if (config.debugLogging) logger.log(`Siri matched command: [${commandDetection.words.join(', ')}]`)
       const response = await commandDetection.function(bl, commandDetection.data)
       if (config.debugLogging) logger.log(`Siri response: ${response}`)
       return response
     }
   }
+  if (config.debugLogging) logger.log(`Siri no match for: ${shortcutParameterAsString}`)
   return `You asked me ${shortcutParameter} and i dont support that command`
 }
 
@@ -209,6 +211,12 @@ async function lock(bl: Bluelink): Promise<string> {
   )
 }
 
+async function walkawayLock(bl: Bluelink): Promise<string> {
+  const status = bl.getCachedStatus()
+  const carName = status.car.nickName || `your ${status.car.modelName}`
+  return await blRequest(bl, 'walkawayLock', `I've issued a request to walkaway lock ${carName}.`)
+}
+
 async function unlock(bl: Bluelink): Promise<string> {
   const status = bl.getCachedStatus()
   return await blRequest(
@@ -263,7 +271,6 @@ async function blRequest(bl: Bluelink, type: string, message: string, payload?: 
   }
   return message
 }
-
 interface commandDetection {
   words: string[]
   function: (bl: Bluelink, data?: any) => Promise<string>
@@ -300,6 +307,10 @@ const commandMap: commandDetection[] = [
   {
     words: ['unlock'],
     function: unlock,
+  },
+  {
+    words: ['walkaway', 'lock'],
+    function: walkawayLock,
   },
   {
     words: ['lock'],


### PR DESCRIPTION
## Description
Added the ability to poll for door status in order to send the lock command, similar to what the electronic devices such as ioniqguy created.
Function polls the `doorOpen` status every 10 seconds with a timeout of 60 seconds. If it times out or `doorOpen === false`, lock the doors.
Also added the command instantiation from the UI via the Car Lock button.
## Testing
test env: USA Hyundai Ioniq 9 and iOS 26
1. Open door, run command, verify logs, close door sometime later, verify door locks.
2. Close all doors, run command, verify logs.
3. Verified iOS Shortcuts launcher
4. Verified Carplay Disconnect Automation

