### PR TITLE
feat(docs): add multi-language support with jekyll-polyglot

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,5 @@
-# Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+# Workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll with GitHub Pages
 
 on:
   # Runs on pushes targeting the default branch
@@ -25,18 +25,29 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@13e7a03dc3ac6c3798f4570bfead2aed4d96abfb # v1.244.0
         with:
-          source: ./docs/
-          destination: ./_site
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: docs
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        with:
+          path: docs/_site
 
   # Deployment job
   deploy:
@@ -48,4 +59,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac2b3c603fc # v4.0.5

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -7,15 +7,14 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-# gem "jekyll", "~> 4.3.4"
-# This is the default theme for new Jekyll sites. You may change this to anything you like.
+gem "jekyll", "~> 4.3"
+# Documentation theme
 gem "just-the-docs"
-# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
-# uncomment the line below. To upgrade, run `bundle update github-pages`.
-gem "github-pages", "~> 232", group: :jekyll_plugins
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
+  gem "jekyll-default-layout"
+  gem "jekyll-polyglot", "~> 1.8"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -30,12 +30,17 @@ url: https://bluelink.andyfase.com  # the base hostname and protocol for your si
 #baseurl: "/docs"      # place folder name if the site is served in a subfolder
 
 # Build settings
-remote_theme: just-the-docs/just-the-docs
-# remote_theme: pages-themes/cayman@v0.2.0
+theme: just-the-docs
 plugins:
   - jekyll-feed
   - jekyll-default-layout
-  # - jekyll-remote-theme
+  - jekyll-polyglot
+
+# Polyglot i18n settings
+languages: ["en", "fr"]
+default_lang: "en"
+exclude_from_localization: ["assets", "CNAME"]
+parallel_localization: false
 
 # Exclude from processing.
 # The following items will not be processed, by default.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,6 +35,7 @@ plugins:
   - jekyll-feed
   - jekyll-default-layout
   - jekyll-polyglot
+  - jekyll-relative-links
 
 # Polyglot i18n settings
 languages: ["en", "fr"]

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -40,7 +40,7 @@ plugins:
 # Polyglot i18n settings
 languages: ["en", "fr"]
 default_lang: "en"
-exclude_from_localization: ["assets", "CNAME"]
+exclude_from_localization: ["images", "app-assets", "CNAME"]
 parallel_localization: false
 
 # Exclude from processing.

--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -8,7 +8,7 @@
       {% else %}
         {% capture lang_url %}/{{ lang }}{{ target_url }}{% endcapture %}
       {% endif %}
-      <option value="{{ lang_url }}" {% if lang == site.active_lang %}selected{% endif %}>
+      <option value="{{ lang_url | relative_url }}" {% if lang == site.active_lang %}selected{% endif %}>
         {%- if lang == "en" -%}🇬🇧 English{%- elsif lang == "fr" -%}🇫🇷 Français{%- else -%}{{ lang }}{%- endif -%}
       </option>
     {% endfor %}

--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -1,0 +1,16 @@
+<div class="language-switcher">
+  <label for="lang-select">Language:</label>
+  <select id="lang-select" onchange="if(this.value)window.location.href=this.value">
+    {% for lang in site.languages %}
+      {% assign target_url = page.url %}
+      {% if lang == site.default_lang %}
+        {% assign lang_url = target_url %}
+      {% else %}
+        {% capture lang_url %}/{{ lang }}{{ target_url }}{% endcapture %}
+      {% endif %}
+      <option value="{{ lang_url }}" {% if lang == site.active_lang %}selected{% endif %}>
+        {%- if lang == "en" -%}🇬🇧 English{%- elsif lang == "fr" -%}🇫🇷 Français{%- else -%}{{ lang }}{%- endif -%}
+      </option>
+    {% endfor %}
+  </select>
+</div>

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -93,4 +93,37 @@
 .btn-primary { color: #fff; background-color: #5739ce; background-image: linear-gradient(#6f55d5, #5739ce); box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25), 0 4px 10px rgba(0, 0, 0, 0.12); }
 .btn-primary:hover, .btn-primary.zeroclipboard-is-hover { color: #fff; background-color: #5132cb; background-image: linear-gradient(#6549d2, #5132cb); }
 .btn-primary:active, .btn-primary.selected, .btn-primary.zeroclipboard-is-active { background-color: #4f31c6; background-image: none; box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15); }
+
+// Language switcher
+.language-switcher {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0;
+  font-size: 0.85rem;
+
+  label {
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  select {
+    appearance: auto;
+    padding: 0.2rem 0.4rem;
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    background: #fff;
+    font-size: 0.85rem;
+    cursor: pointer;
+
+    &:hover {
+      border-color: #9ca3af;
+    }
+
+    &:focus {
+      outline: 2px solid #7253ed;
+      outline-offset: 1px;
+    }
+  }
+}
 .btn-primary.selected:hover { background-color: #472cb2; }

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -1,0 +1,74 @@
+---
+title: Accueil
+nav_order: 1
+layout: home
+lang: fr
+permalink: /
+---
+
+# Application Scriptable Hyundai / Kia E‑GMP pour iOS
+{: .fs-8 }
+
+Une [application Scriptable](https://scriptable.app/) pour iOS qui vous permet de contrôler votre voiture Hyundai / Kia E‑GMP via l'API Bluelink.
+Considérez-la comme une application compagnon de l'application officielle Bluelink, avec une interface plus moderne, plus réactive et des fonctionnalités étendues telles que le widget et la prise en charge de Siri.
+{: .fs-6 .fw-300 }
+
+
+<script>
+function lightbox_open() {
+  var lightBoxVideo = document.getElementById("VisaChipCardVideo");
+  window.scrollTo(0, 0);
+  document.getElementById('light').style.display = 'block';
+  document.getElementById('fade').style.display = 'block';
+  lightBoxVideo.play();
+}
+
+function lightbox_close() {
+  var lightBoxVideo = document.getElementById("VisaChipCardVideo");
+  document.getElementById('light').style.display = 'none';
+  document.getElementById('fade').style.display = 'none';
+  lightBoxVideo.pause();
+}
+</script>
+
+<div id="light">
+  <a class="boxclose" id="boxclose" onclick="lightbox_close();"></a>
+  <video id="VisaChipCardVideo" height="680" autoplay controls>
+      <source src="../images/egmp-scriptable-in-use.mp4" type="video/mp4">
+      <!--Browser does not support <video> tag -->
+    </video>
+</div>
+
+<div id="fade" onClick="lightbox_close();"></div>
+
+<table border="0" class="noBorder">
+<tr>
+<td width="55%"><a href="#" onclick="lightbox_open();"><img src="../images/widget_charging.png" width="400" /></a>
+<br/><center>Cliquez pour afficher l'application en action</center>
+</td>
+<td>
+
+<p>
+<a href="/pages/install.html" class="btn btn-primary fs-5 mb-4 mb-md-0 mr-2">Instructions d'installation</a>
+</p>
+<p>
+<a href="https://github.com/andyfase/egmp-bluelink-scriptable" class="btn fs-5 mb-4 mb-md-0">Voir sur GitHub&#160;&#160;</a>
+</p>
+<p>
+<a href="https://buymeacoffee.com/andyfase"><img src="../images/coffee.png" width="188"></a>
+</p>
+
+</td>
+</tr>
+</table>
+
+Fonctionnalités :
+{: .fs-6 .fw-300 }
+
+- Widgets d'écran d'accueil et d'écran de verrouillage auto-mis à jour
+- Interface plus moderne et plus réactive
+- Options en un clic pour les commandes courantes (verrouiller, chauffer, charger, etc.) dans l'application et dans le Centre de contrôle iOS
+- Prise en charge vocale Siri « Dis Siri, chauffe la voiture »
+- Automatisations via Raccourcis iOS, par exemple verrouillage automatique à l'éloignement
+- Configurations de climatisation personnalisées illimitées
+{: .fs-6 .fw-300 }

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -49,7 +49,7 @@ function lightbox_close() {
 <td>
 
 <p>
-<a href="/pages/install.html" class="btn btn-primary fs-5 mb-4 mb-md-0 mr-2">Instructions d'installation</a>
+<a href="{{ site.baseurl }}/{{ page.lang }}/pages/install.html" class="btn btn-primary fs-5 mb-4 mb-md-0 mr-2">Instructions d'installation</a>
 </p>
 <p>
 <a href="https://github.com/andyfase/egmp-bluelink-scriptable" class="btn fs-5 mb-4 mb-md-0">Voir sur GitHub&#160;&#160;</a>

--- a/docs/fr/pages/automations.md
+++ b/docs/fr/pages/automations.md
@@ -1,0 +1,77 @@
+---
+title: Automatisations
+layout: home
+nav_order: 6
+lang: fr
+permalink: /pages/automations.html
+---
+
+# Automatisations
+{: .fs-9 }
+
+En utilisant les Raccourcis iOS, il est possible de configurer plusieurs automatisations. Une automatisation associe un raccourci défini à une automatisation iOS qui déclenchera ce raccourci en fonction d'un événement (par ex. heure, déconnexion Bluetooth, etc.).
+{: .fs-5 .fw-300 }
+
+Toute automatisation basée sur un raccourci doit invoquer l'application avec une commande donnée — sous forme de chaîne de texte. La liste des commandes est décrite sur la page [Siri](./siri.md).
+{: .fs-5 .fw-300 }
+
+## Exemples d'automatisations
+
+Voici quelques exemples d'automatisations et des raccourcis Shortcuts téléchargeables. Les raccourcis fournis sont des exemples et doivent être modifiés par vos soins pour correspondre à ce que vous souhaitez réaliser.
+{: .fs-5 .fw-300 }
+
+### Verrouillage automatique à l'éloignement
+
+{: .warning-title }
+> Attention : vous pouvez vous retrouver enfermé hors de votre voiture en utilisant cette fonctionnalité.
+>
+> Le verrouillage via Bluelink verrouille toujours, quel que soit l'emplacement de vos clés. Ainsi, l'auto-verrouillage via Bluelink signifie que si vous coupez le contact, laissez vos clés dans la voiture et quittez le véhicule, les portes se verrouilleront.
+>
+> Si vous utilisez cette fonctionnalité, ne quittez jamais le véhicule sans disposer d'une de vos clés ou de votre téléphone avec l'application installée (afin de pouvoir déverrouiller si nécessaire).
+
+Cette automatisation enverra une commande de verrouillage au véhicule après un délai. L'événement déclencheur peut être la déconnexion de CarPlay ou la déconnexion du Bluetooth du véhicule.
+
+[Installer le raccourci « Auto Lock Car »](https://www.icloud.com/shortcuts/2b49acde29904725b31c64f8195074ce)
+{: .fs-5 .fw-300 }
+
+Pour configurer l'automatisation, procédez comme suit :
+
+- Cliquez sur l'onglet Automatisations
+- Appuyez sur le bouton plus (+)
+- Choisissez soit "Bluetooth" soit "CarPlay"
+- Sélectionnez "Est déconnecté" comme déclencheur (pas connecté), choisissez l'appareil (par ex. le nom Bluetooth ou CarPlay du véhicule). Enfin, sélectionnez "Exécuter immédiatement"
+
+### Jour de travail : réchauffer automatiquement la voiture si elle est froide
+
+Cette automatisation enverra une commande de chauffe au véhicule selon un calendrier défini (par ex. 7 h les jours ouvrables), si la température extérieure est inférieure à une valeur donnée.
+
+[Installer le raccourci « Auto Warm Car »](https://www.icloud.com/shortcuts/804d551c2816436698ba97838ea66c26)
+{: .fs-5 .fw-300 }
+
+Pour configurer l'automatisation, procédez comme suit :
+
+- Cliquez sur l'onglet Automatisations
+- Appuyez sur le bouton plus (+)
+- Choisissez "Heure de la journée"
+- Sélectionnez l'heure à laquelle vous souhaitez que l'automatisation s'exécute, choisissez "Hebdomadaire" et sélectionnez les jours de la semaine où vous voulez qu'elle s'exécute. Enfin, sélectionnez "Exécuter immédiatement"
+
+### Régler la limite de charge à 100 % une fois par mois
+
+Hyundai / Kia recommandent de charger à 100 % une fois par mois ; cela peut être difficile à se rappeler. Cette automatisation est utile si vous chargez habituellement quotidiennement (ou régulièrement) et que vous souhaitez automatiser ce réglage ponctuel.
+
+Cette automatisation enverra une commande de limite de charge au véhicule selon un calendrier défini. Dupliquez-la pour la remettre à la valeur normale le lendemain.
+
+[Installer le raccourci « Auto Charge Limit »](https://www.icloud.com/shortcuts/2c499728f55d43aa90ba9b68792fe9df)
+{: .fs-5 .fw-300 }
+
+Modifiez le script pour définir le réglage de charge de votre choix ; par défaut il est défini sur "RoadTrip". Vous souhaiterez probablement créer votre propre réglage de limite de charge dans les paramètres de configuration de l'application.
+
+Pour configurer l'automatisation, procédez comme suit :
+
+- Cliquez sur l'onglet Automatisations
+- Appuyez sur le bouton plus (+)
+- Choisissez "Heure de la journée"
+- Sélectionnez l'heure à laquelle vous souhaitez que l'automatisation s'exécute, choisissez "Mensuel" et sélectionnez le jour du mois auquel vous voulez qu'elle s'exécute. Enfin, sélectionnez "Exécuter immédiatement"
+
+Dupliquez le script et l'automatisation pour rétablir ensuite la limite de charge à sa valeur normale.
+{: .fs-5 .fw-300 }

--- a/docs/fr/pages/control-center.md
+++ b/docs/fr/pages/control-center.md
@@ -1,0 +1,32 @@
+---
+title: Centre de contrôle
+layout: home
+nav_order: 6
+lang: fr
+permalink: /pages/control-center.html
+---
+
+# Prise en charge du Centre de contrôle
+{: .fs-9 }
+
+Une fois que vous avez installé les raccourcis courants listés sur la page [Siri](./siri.md), ces raccourcis (verrouiller, déverrouiller, chauffer, refroidir) peuvent être configurés comme icônes à un seul clic dans le [Centre de contrôle iOS](https://support.apple.com/en-ca/guide/iphone/iph59095ec58/ios).
+{: .fs-5 .fw-300 }
+
+Lorsque la configuration est terminée, les quatre contrôles inférieurs seront disponibles comme sur la capture d'écran ci-dessous :
+{: .fs-5 .fw-300 }
+
+<img src="../images/control-center.jpg" width="300px">
+
+## Configuration
+
+Pour configurer ces commandes, suivez la section « Personnaliser les contrôles » des [instructions Apple](https://support.apple.com/en-ca/guide/iphone/iph59095ec58/ios).
+{: .fs-5 .fw-300 }
+
+- Choisissez « Ajouter un contrôle »
+- Recherchez et sélectionnez « Raccourci »
+- Choisissez l'un des raccourcis courants installés depuis la page [Siri](./siri.md)
+- Redimensionnez le contrôle en un petit cercle — l'icône correcte s'affichera automatiquement
+{: .fs-5 .fw-300 }
+
+Répétez les étapes ci‑dessus pour les 4 contrôles.
+{: .fs-5 .fw-300 }

--- a/docs/fr/pages/faq.md
+++ b/docs/fr/pages/faq.md
@@ -1,0 +1,63 @@
+---
+title: Aide
+layout: home
+nav_order: 8
+lang: fr
+permalink: /pages/faq.html
+---
+
+# Aide / FAQ
+{: .fs-9 }
+
+Vous trouverez ci‑dessous une liste de questions fréquentes et/ou de problèmes courants, avec leurs solutions possibles.
+{: .fs-5 .fw-300 }
+
+### Est‑ce une vraie application, et si non pourquoi ?
+
+Non, il ne s'agit pas d'une application distribuée sur l'App Store d'Apple. C'est un « app » ou script pour [Scriptable](https://scriptable.app/). Vous devez donc installer l'application Scriptable depuis l'App Store puis importer/installer le script fourni dans ce dépôt. Tout est documenté dans la [page d'installation](./install.md).
+
+Pourquoi ce choix ? Parce que c'est plus simple à développer et à déployer de cette façon, et cela évite certaines contraintes imposées par l'App Store. Cette application utilise des API Hyundai et Kia non documentées ; cela rend la publication sur l'App Store plus compliquée et sujette à des restrictions.
+
+### Le support Android est‑il prévu ?
+
+Non, cette application est uniquement pour iOS et il n'est pas prévu pour l'instant de version Android. [Scriptable](https://scriptable.app/) n'existe que sur iOS ; l'équivalent Android le plus proche serait Tasker. Pour porter ceci sur Android, il faudrait développer une application native ou en React Native et la distribuer (probablement en sideload). Ce projet actuel ne couvre pas cela.
+
+### Ai‑je besoin d'un abonnement Bluelink Kia / Hyundai pour utiliser l'application ?
+
+Oui, en général. L'application utilise les mêmes API Hyundai/Kia que les applications officielles ; il est donc supposé que vous ayez un compte Bluelink actif et les droits nécessaires pour contrôler le véhicule depuis ces API.
+
+### Mes identifiants Bluelink sont‑ils en sécurité si je les entre dans l'application ?
+
+Oui. Toutes les configurations (y compris votre nom d'utilisateur, mot de passe et code PIN Bluelink) sont stockées localement dans le trousseau iOS (iOS keychain). Les identifiants ne sont exposés que si vous activez les logs de débogage (Debug Logging) et partagez ensuite ces logs. Faites attention aux logs avant de les partager.
+
+### Quels pays / constructeurs sont pris en charge ?
+
+Voir la page [Régions](./region.md) pour la liste des régions prises en charge et les limitations éventuelles.
+
+### Les véhicules à moteur thermique (ICE) sont‑ils pris en charge ?
+
+Pas pour l'instant. Cette application a été développée spécifiquement pour les véhicules électriques Hyundai / Kia basés sur la plateforme E‑GMP. Le support des véhicules à moteur thermique (ICE) a été demandé et pourra être envisagé, mais n'est pas encore implémenté. Si vous souhaitez le support ICE, veuillez ouvrir une issue sur [GitHub](https://github.com/andyfase/egmp-bluelink-scriptable/issues) pour en discuter.
+
+### J'ai saisi mes identifiants de façon incorrecte et l'application ne s'ouvre plus / ne fait rien
+
+Vous devrez réinitialiser la configuration stockée. Un script de « reset » est fourni dans les [releases GitHub](https://github.com/andyfase/egmp-bluelink-scriptable/releases). Téléchargez le fichier « egmp-reset.js » sous Assets dans votre répertoire Scriptable et exécutez-le pour réinitialiser la configuration.
+
+### J'ai trouvé un bug et j'aimerais qu'il soit corrigé
+
+Veuillez ouvrir une [issue GitHub](https://github.com/andyfase/egmp-bluelink-scriptable/issues) et fournir toutes les informations concernant le problème rencontré. Il est probable que des logs de débogage soient nécessaires — voir la question suivante.
+
+### Comment activer et obtenir les logs de débogage ?
+
+Assurez‑vous d'utiliser la version v1.2.0 (ou supérieure), car cette version facilite l'accès aux logs de débogage.
+
+Une fois sur une version compatible, allez dans l'écran des paramètres de l'application et activez l'option « Debug logs ». Lorsqu'elle est activée, chaque requête et réponse API envoyée par l'application est consignée dans les logs.
+
+Exécutez ensuite les actions nécessaires pour reproduire le bug. Quand vous avez terminé, effectuez un triple‑appui sur l'icône des paramètres et choisissez « Share Debug Logs ». Un écran de partage s'ouvrira vous permettant d'envoyer les logs. Les logs sont automatiquement expurgés de toute information personnelle (nom d'utilisateur, mot de passe, code PIN, etc.).
+
+### Comment obtenir la liste complète des fichiers de logs en dehors de l'application ?
+
+Les fichiers de logs sont stockés dans le répertoire Scriptable sur iCloud Drive. Le fichier actif est nommé `egmp-bluelink.log`. Les fichiers de logs sont automatiquement renommés lorsqu'ils atteignent 100 ko. Vous verrez donc des fichiers anciens nommés `egmp-bluelink.log.20250318150755-0700` ou similaires. L'horodatage correspond à la date de renommage du fichier.
+
+Tous les fichiers de logs se trouvent dans le même répertoire Scriptable que les scripts eux-mêmes. Attention : ces fichiers de logs peuvent contenir vos identifiants. Si on vous demande de fournir des logs, veuillez les vérifier et supprimer ou masquer vos identifiants avant de les partager.
+
+----

--- a/docs/fr/pages/features.md
+++ b/docs/fr/pages/features.md
@@ -1,0 +1,27 @@
+---
+title: Fonctionnalités
+layout: home
+nav_order: 3
+lang: fr
+permalink: /pages/features.html
+---
+
+# Fonctionnalités
+{: .fs-9 }
+
+Bluelink Scriptable offre plusieurs fonctionnalités pour améliorer l'expérience d'utilisation de votre Hyundai / Kia E‑GMP :
+{: .fs-5 .fw-300 }
+
+- Widgets d'écran d'accueil et d'écran de verrouillage auto‑mis à jour
+- Interface utilisateur plus moderne et réactive
+- Commandes en un clic pour les actions courantes (verrouiller, chauffer, démarrer la charge, etc.)
+- Prise en charge Siri pour contrôler la voiture par la voix
+- Automatisations via Raccourcis iOS
+- Configurations climatiques personnalisées et illimitées
+- Gestion de plusieurs véhicules (voir la page [Multi‑véhicule](./multi-car.md))
+{: .fs-5 .fw-300 }
+
+Chaque fonctionnalité peut être personnalisée dans les paramètres de l'application afin de s'adapter à vos besoins.
+{: .fs-5 .fw-300 }
+
+----

--- a/docs/fr/pages/install.md
+++ b/docs/fr/pages/install.md
@@ -1,0 +1,62 @@
+---
+title: Installation
+layout: home
+nav_order: 4
+lang: fr
+permalink: /pages/install.html
+---
+
+# Instructions d'installation
+{: .fs-9 }
+
+{: .info-title }
+> Ce n'est pas une application de l'App Store
+>
+> Bluelink Scriptable est une application "scriptable". C'est un script qui est lu dans [scriptable IOS app](https://scriptable.app/), comme une app dans une app. Cela signifie qu'il faut installer l'application Scriptable depuis l'App Store puis télécharger le Javascript dans l'application Scriptable de votre iPhone.
+>
+>Utiliser Scriptable signifie un temps de développement beaucoup plus rapide, pas de processus d'acceptation compliqué de la part d'apple et des mises à jour ultra rapides quand Kia ou Hyundai changent leur API! Vous aurez quand même l'impression d'utiliser une application incluant les widgets, raccourcis, Siri et bien plus!
+
+> Il n'y a besoin que d'une seule installation. Une fois que c'est fait les mises à jour vous seront proposées à l'ouverture de l'app, quand disponibles, en un seul clic.
+{: .fs-5 .fw-300 }
+
+## Étapes d'installation
+
+Step 1: [Installer l'app Scriptable](https://apps.apple.com/us/app/scriptable/id1405459188?uo=4)
+puis l'ouvrir.
+{: .fs-4 .fw-300 }
+
+Step 2: [Télécharger la dernière version de egmp-bluelink.js](https://github.com/andyfase/egmp-bluelink-scriptable/releases) depuis votre iPhone.
+{: .fs-4 .fw-300 }
+
+![image](../images/download.png)
+
+Step 3: Depuis l'application iOS **Fichiers**, déplacer le fichier `egmp-bluelink.js` du dossier téléchargements vers "iCloud Drive" -> "Scriptable".
+{: .fs-4 .fw-300 }
+
+Step 4: Ouvrir l'app Scriptable et sélectionner "egmp-bluelink". Ça lancera l'app pour la première fois et un écran de configuration s'affichera, vous demandant de rentrer vos informations de Bluelink et indiquer vos préférences.
+{: .fs-4 .fw-300 }
+
+> Note: Vos informations Bluelink sont stockées en sécurité dans votre trousseau Apple et l'app scriptable n'envoie jamais ces informations ailleurs qu'à l'API Bluelink, tout comme l'appli officielle Bluelink.
+
+Step 5: Une fois vos informations entrées, cliquez sur enregistrer (save) et l'application fermera. Appuyez sur "egmp-bluelink" de nouveau et l'app s'ouvrira et sera utilisable!
+{: .fs-5 .fw-300 }
+
+Step 6: Créez un nouveau widget pour votre écran verrouillé ou écran d'Accueil. [Voir le guide Apple si besoin d'aide](https://support.apple.com/en-ca/118610). La [Page Widget](./widgets.md) vous montrera les widgets disponibles.
+{: .fs-5 .fw-300 }
+
+Quand vous configurez le widget, veuillez vous assurer de :
+{: .fs-5 .fw-300 }
+
+- Choisir **"Scriptable"** depuis la liste des widgets
+- Choisir la taille medium (la seule supportée)
+- Rester appuyé sur votre widget pour le configurer
+- Pour **"Script"** choisir **egmp-bluelink**
+- Pour **"When Interacting"** choisir **Run Script**
+
+Step 7: (Optionnel mais recommandé) Continuez en installant les [raccourcis Siri iOS](./siri.md) et les [contrôles du centre de contrôle](./control-center.md).
+{: .fs-5 .fw-300 }
+
+Ça y est c'est fini! Profitez de bluelink-scriptable!
+{: .fs-5 .fw-300 }
+
+----

--- a/docs/fr/pages/multi-car.md
+++ b/docs/fr/pages/multi-car.md
@@ -1,0 +1,31 @@
+---
+title: Multi‑véhicule
+layout: home
+nav_order: 7
+lang: fr
+permalink: /pages/multi-car.html
+---
+
+# Gestion de plusieurs véhicules
+{: .fs-9 }
+
+{: .info-title }
+> Plusieurs widgets, un pour chacun de vos VE.
+>
+> Pour les foyers possédant plus d'un VE Hyundai ou Kia, vous pouvez exécuter plusieurs copies de l'application egmp-bluelink, chacune configurée pour récupérer les données d'un véhicule spécifique.
+>
+> Chaque véhicule nécessite sa propre configuration et peut être dans le même compte Bluelink ou dans des comptes différents, voire de constructeurs différents.
+{: .fs-5 .fw-300 }
+
+## Activer le support multi-véhicule
+
+Depuis la v1.2.0, le support multi-véhicule est activé par défaut. Configurez simplement le [script comme d'habitude](./install.md) pour votre premier véhicule.
+{: .fs-5 .fw-300 }
+
+Une fois configuré, dans l'application Scriptable, restez appuyé sur la ligne « egmp-bluelink » et sélectionnez « Dupliquer », ce qui ouvrira une fenêtre de code — cliquez simplement sur « Done ». Cela produira un script probablement nommé « egmp-bluelink 1 », n'hésitez pas à le renommer (restez appuyé et choisissez renommer).
+{: .fs-5 .fw-300 }
+
+Ouvrez maintenant le nouveau script, il vous demandera les paramètres Bluelink comme lors de la première installation, procédez à la configuration des mêmes paramètres mais pour votre deuxième véhicule. Une fois configuré, vous pouvez créer un nouveau widget pour ce deuxième véhicule — assurez-vous simplement de sélectionner le nouveau script scriptable lors de la configuration du widget.
+{: .fs-5 .fw-300 }
+
+----

--- a/docs/fr/pages/region.md
+++ b/docs/fr/pages/region.md
@@ -1,30 +1,31 @@
 ---
-title: Region / Brand Support
+title: Région et disponibilité
 layout: home
 nav_order: 2
-lang: en
+lang: fr
+permalink: /pages/region.html
 ---
 
-# Region and Brand Support
+# Régions et marques prises en charge
 {: .fs-9 }
 
-The app uses the publically exposed BlueLink API, it is un-documented and varies in specification across both manufacturer and region.
+L'application utilise les API publiées par Bluelink qui ne sont pas documentées et varient en possibilités selon la marque et la région.
 {: .fs-6 .fw-300 }
 
-As such support for each region / manufacturer requires custom development and testing. The current level of support is shown below.
+Par conséquent, le support pour chaque région/fabricant nécessite un développement et des tests personnalisés. Le niveau de support actuel est indiqué ci-dessous.
 {: .fs-5 .fw-300 }
 
-If you can confirm support for any un-tested regions (Noted via question-mark icon) or encounter a bug on a region that is supported, feel free to [DM me on reddit](https://www.reddit.com/user/andyfase/) or [raise a issue on github](https://github.com/andyfase/egmp-bluelink-scriptable/issues).
+Si vous pouvez confirmer le support pour des régions non testées (indiquées par une icône point d'interrogation) ou si vous rencontrez un bug dans une région supportée, n'hésitez pas à m'envoyer un message privé [DM me on reddit](https://www.reddit.com/user/andyfase/) ou à [raise a issue on github](https://github.com/andyfase/egmp-bluelink-scriptable/issues).
 {: .fs-5 .fw-300 }
 
-# Current Known Region Support
+# Régions supportées
 {: .fs-7 }
 
 <table class="styled-table">
 <thead>
   <tr>
-    <th class="styled-table-col">Brand</th>
-    <th>Region</th>
+    <th class="styled-table-col">Marque</th>
+    <th>Région</th>
     <th>Support</th>
   </tr>
 </thead>
@@ -43,12 +44,12 @@ If you can confirm support for any un-tested regions (Noted via question-mark ic
 <td><img src="../images/checkmark.png" width="30"/></td>
 </tr>
 <tr>
-<td>Australia</td>
+<td>Australie</td>
 <td><img src="../images/checkmark.png" width="30"/></td>
 </tr>
 
 <tr  class="styled-table-row">
-<td>India</td>
+<td>Inde</td>
 <td><img src="../images/checkmark.png" width="30"/></td>
 </tr>
 
@@ -69,7 +70,7 @@ If you can confirm support for any un-tested regions (Noted via question-mark ic
 </td>
 </tr>
 <tr>
-<td>Australia</td>
+<td>Australie</td>
 <td>
 <img src="../images/checkmark.png" width="30"/>
 <img src="../images/question.png" width="30"/>
@@ -77,7 +78,7 @@ If you can confirm support for any un-tested regions (Noted via question-mark ic
 </tr>
 
 <tr  class="styled-table-row">
-<td>India</td>
+<td>Inde</td>
 <td><img src="../images/cross.png" width="30"/></td>
 </tr>
 
@@ -99,14 +100,14 @@ If you can confirm support for any un-tested regions (Noted via question-mark ic
 </td>
 </tr>
 <tr>
-<td>Australia</td>
+<td>Australie</td>
 <td>
 <img src="../images/cross.png" width="30"/>
 </td>
 </tr>
 
 <tr>
-<td>India</td>
+<td>Inde</td>
 <td><img src="../images/cross.png" width="30"/></td>
 </tr>
 
@@ -114,7 +115,7 @@ If you can confirm support for any un-tested regions (Noted via question-mark ic
 </tbody>
 </table>
 
-If your region is not supported and your willing to provide secondary driver access to your bluelink account, so I can obtain network traces to support your region please [DM me on reddit](https://www.reddit.com/user/andyfase/). As I am much more likely to work on the support of your region If I have access to the APIs and offical app to trace and test with.
+Si votre région n'est pas prise en charge et que vous êtes prêt(e) à fournir un accès conducteur secondaire à votre compte Bluelink afin que je puisse obtenir des traces réseau pour prendre en charge votre région, veuillez m'envoyer un message privé sur Reddit [DM me on reddit](https://www.reddit.com/user/andyfase/). Il est beaucoup plus probable que je travaille sur le support de votre région si j'ai accès aux API et à l'application officielle pour effectuer le traçage et les tests nécessaires.
 {: .fs-3 .fw-300 }
 
 ----

--- a/docs/fr/pages/siri.md
+++ b/docs/fr/pages/siri.md
@@ -1,0 +1,191 @@
+---
+title: Siri / Raccourcis
+layout: home
+nav_order: 5
+lang: fr
+permalink: /pages/siri.html
+---
+
+# Raccourcis Siri
+{: .fs-9 }
+
+L'application supporte les interactions avec Siri grâce à l'app « Raccourcis » d'iOS. Plusieurs liens de téléchargement de raccourcis sont disponibles ci-dessous. Ils peuvent être utilisés autant pour demander à Siri que via le [centre de contrôle iOS](./control-center.md).
+{: .fs-5 .fw-300 }
+
+## Commandes courantes
+
+Les raccourcis peuvent être utilisés via Siri ou le [centre de contrôle](./control-center.md).
+
+### Lock the Car - « Dis Siri, Lock the car »
+[Installer le raccourci « Lock Car »](https://www.icloud.com/shortcuts/5b569f78ef00452b9d7fe4455635d36d)
+{: .fs-5 .fw-300 }
+
+### UnLock the Car - « Dis Siri, Unlock the car »
+[Installer le raccourci « Unlock the Car »](https://www.icloud.com/shortcuts/631cb0865dfc4358837485410eb2a46f)
+{: .fs-5 .fw-300 }
+
+### Warm the Car - « Dis Siri, warm the car »
+[Installer le raccourci « Warm the Car »](https://www.icloud.com/shortcuts/ea24582e07e44edea66b0d7a9773ea75)
+{: .fs-5 .fw-300 }
+
+### Cool the Car - « Dis Siri, Cool the car »
+[Installer le raccourci « Cool the Car »](https://www.icloud.com/shortcuts/486487c8d3c841feb9d4b46476eef294)
+{: .fs-5 .fw-300 }
+
+
+
+## Raccourci « Ask the Car »
+[Installer le raccourci « Ask the Car »](https://www.icloud.com/shortcuts/b3bd704fa2bf4c6dabceec096c291342)
+{: .fs-5 .fw-300 }
+
+Une fois installé, interagissez avec le raccourci en disant **« Dis Siri, Ask the car »**. Siri répondra en demandant **« Whats the Command? »** et vous pourrez répondre avec une phrase en langage naturel, qui sera transmise à l'application. L'application identifie les commandes en correspondant à des mots-clés spécifiques, listés ci-dessous.
+{: .fs-5 .fw-300 }
+
+Une interaction commence par vous demander à Siri d'exécuter le nom du raccourci, dans ce cas nommé « Ask the Car », donc une interaction ressemble à :
+{: .fs-5 .fw-300 }
+
+**Vous : « Dis Siri, Ask the car »**  *(Ceci exécute le raccourci)*
+**Siri : « Whats the Command? »**  *(Le raccourci demande une entrée)*
+**Vous : « What's the status of the car? »**  *(Votre entrée sera envoyée à l'application)*
+**Siri : « Your Ioniq 5's battery is at 75% and locked. Your car is also charging at 6kw and will be finished at 9pm »** *(C'est la réponse de l'application que Siri vous lira)*
+{: .fs-5 .fw-400 }
+
+Vous pouvez changer le nom du raccourci ou le texte de commande — rappelez-vous simplement que si vous changez le nom, c'est ce que vous devrez dire pour démarrer l'interaction.
+{: .fs-5 .fw-300 }
+
+## Mots-clés supportés
+
+Les mots-clés suivants sont supportés :
+{: .fs-5 .fw-400 }
+
+### Status
+
+Retourne le dernier statut du véhicule depuis l'API Bluelink. Généralement une phrase indiquant le statut de charge, si le véhicule est verrouillé et s'il est en charge (et quand la charge sera terminée).
+{: .fs-5 .fw-400 }
+
+Exemple : « What's the **status** of the car? »
+{: .fs-5 .fw-400 }
+
+### Remote Status
+
+Envoie une commande de statut à distance au véhicule pour obtenir les informations les plus récentes. Une commande de statut normale devra être envoyée environ 30 secondes plus tard pour récupérer ces informations.
+{: .fs-5 .fw-400 }
+
+Exemple : « What's the **remote status** of the car? »
+{: .fs-5 .fw-400 }
+
+### Lock
+
+Envoie une commande de verrouillage à distance au véhicule.
+{: .fs-5 .fw-400 }
+
+Exemple : « Please **lock** the car? »
+{: .fs-5 .fw-400 }
+
+### Unlock
+
+Envoie une commande de déverrouillage à distance au véhicule.
+{: .fs-5 .fw-400 }
+
+Exemple : « Please **unlock** the car? »
+{: .fs-5 .fw-400 }
+
+### Cool
+
+Envoie une commande à distance pour pré-refroidir le véhicule.
+{: .fs-5 .fw-400 }
+
+Exemple : « Can you start **cooling** the car? »
+{: .fs-5 .fw-400 }
+
+### Warm
+
+Envoie une commande à distance pour pré-chauffer le véhicule.
+{: .fs-5 .fw-400 }
+
+Exemple : « Can you start **warming** the car? »
+{: .fs-5 .fw-400 }
+
+### Climate off
+
+Envoie une commande à distance pour arrêter la climatisation du véhicule.
+{: .fs-5 .fw-400 }
+
+Exemple : « Turn the **climate off** please »
+{: .fs-5 .fw-400 }
+
+### Custom Climate Start
+
+Envoie une commande à distance pour démarrer la climatisation selon votre configuration personnalisée (créée dans les paramètres). Cette option est déclenchée par le mot « climate » plus le nom de la configuration personnalisée.
+
+Par exemple, avec une configuration nommée « Super Hot » :
+
+Exemple : « Turn on **climate super hot** please »
+
+### Start charging
+
+Envoie une commande à distance pour démarrer la charge du véhicule.
+{: .fs-5 .fw-400 }
+
+Exemple : « **Start charging** the car »
+{: .fs-5 .fw-400 }
+
+### Stop charging
+
+Envoie une commande à distance pour arrêter la charge du véhicule.
+{: .fs-5 .fw-400 }
+
+Exemple : « **Stop charging** the car »
+{: .fs-5 .fw-400 }
+
+### Set Charge Limits
+Envoie une commande à distance pour définir la limite de charge nommée du véhicule (c.-à-d. le pourcentage de batterie auquel la charge s'arrête).
+{: .fs-5 .fw-400 }
+
+Exemple : « Set **Charge Limit RoadTrip** »
+{: .fs-5 .fw-400 }
+
+### Data
+Mot-clé avancé qui peut être utilisé dans les Raccourcis iOS pour extraire le statut du véhicule dans un dictionnaire de raccourcis pour une utilisation ultérieure. Ces données peuvent ensuite être utilisées dans n'importe quelle condition souhaitée. Par exemple, vous pourriez définir un raccourci qui vérifie chaque soir l'autonomie du véhicule par rapport aux entrées du calendrier et alerte si un road-trip est prévu et que l'autonomie est faible.
+{: .fs-5 .fw-400 }
+
+Les données extraites sont au format suivant :
+
+```
+{
+    "car": {
+        "id": string,
+        "vin": string,
+        "nickName": string,
+        "modelName": string,
+        "modelYear": string,
+        "modelColour": string,
+        "modelTrim": string
+    },
+    "status": {
+        "lastStatusCheck": int # epoch_milliseconds_since_last_api_status,
+        "lastRemoteStatusCheck": int # <epoch_milliseconds_since_last_remote_api_status>,
+        "isCharging": boolean,
+        "isPluggedIn": boolean,
+        "chargingPower": int,
+        "remainingChargeTimeMins": int,
+        "range": int,
+        "locked": boolean,
+        "climate": boolean,
+        "soc": int,
+        "twelveSoc": int,
+        "odometer": float,
+        "location": {
+            "latitude": string,
+            "longitude": string
+        },
+        "chargeLimit": {
+            "dcPercent": int,
+            "acPercent": int
+        }
+    }
+}
+```
+
+Exemple : « **data** »
+{: .fs-5 .fw-400 }

--- a/docs/fr/pages/widgets.md
+++ b/docs/fr/pages/widgets.md
@@ -1,0 +1,98 @@
+---
+title: Widgets
+layout: home
+nav_order: 2
+lang: fr
+permalink: /pages/widgets.html
+---
+
+# Support des widgets
+{: .fs-9 }
+
+Bluelink Scriptable prend en charge les widgets d'écran de verrouillage et d'écran d'accueil.
+{: .fs-6 .fw-300 }
+
+Tous les widgets permettent d'accéder à l'application principale en un seul clic et de mettre à jour automatiquement les données du véhicule en arrière-plan.
+{: .fs-5 .fw-300 }
+
+{: .info-title }
+> Actualisation à distance des widgets
+>
+> Il est à noter que la mise à jour automatique des données du véhicule est « opt-in » : vous devez activer le paramètre « Enable widget remote refresh » dans l'écran des paramètres pour activer cette fonctionnalité. Cette fonctionnalité envoie automatiquement des commandes de statut à distance au véhicule pour obtenir des données à jour.
+>
+> Ceci est nécessaire pour obtenir les dernières données directement du véhicule. Sans activer ce paramètre, votre widget affichera probablement des données obsolètes.
+>
+> Une décharge de la batterie 12V peut survenir si vous envoyez trop de commandes de rafraîchissement à distance. Les valeurs par défaut de l'application sont très conservatrices pour cette raison. Ne modifiez les paramètres avancés des widgets que si vous comprenez les conséquences potentielles.
+{: .fs-5 .fw-300 }
+
+## Widgets d'écran d'accueil
+
+Ces widgets peuvent être ajoutés à votre écran d'accueil. [Voir les instructions Apple](https://support.apple.com/en-ca/118610). Ce sont des widgets plus grands qui peuvent afficher plus d'informations et être placés sur n'importe quel écran d'accueil.
+{: .fs-5 .fw-300 }
+
+<table border="0" class="noBorder">
+<tr>
+<td width="40%">
+<img src="../images/widget_home_big.png" width="500"/>
+</td>
+<td>
+<p><b>Taille moyenne</b></p>
+<p>Affiche le nom du véhicule (surnom si défini, sinon le nom du modèle), une grande image du véhicule et des informations sur la capacité de la batterie et l'autonomie. Si le véhicule est en charge ou branché, des icônes s'affichent en conséquence avec la puissance de charge et l'heure estimée de fin de charge. L'odomètre et la date/heure du dernier contrôle de statut à distance sont également visibles.</p>
+</td>
+</tr>
+<tr>
+<td>
+<img src="../images/widget_home_small.png" width="150"/>
+</td>
+<td>
+<p><b>Petite taille</b></p>
+<p>Affiche une petite image du véhicule et des informations sur la capacité de la batterie et l'autonomie. Si le véhicule est en charge ou branché, des icônes s'affichent en conséquence avec la puissance de charge et l'heure estimée de fin de charge. La date/heure du dernier contrôle de statut à distance est également visible.</p>
+</td>
+
+</tr>
+</table>
+
+## Widgets d'écran de verrouillage
+
+Ces widgets peuvent être ajoutés à votre écran de verrouillage. [Voir les instructions Apple](https://support.apple.com/en-ca/118610). Ces widgets sont petits, transparents et s'harmonisent avec les autres widgets d'écran de verrouillage Apple (météo, etc.).
+{: .fs-5 .fw-300 }
+
+<table border="0" class="noBorder">
+
+<tr>
+<td width="40%">
+<img src="../images/widget_lock_big.png" width="300"/>
+</td>
+<td>
+<p><b>Grande taille</b></p>
+<p>Affiche un « cercle de batterie » reflétant la capacité de la batterie. Affiche également l'autonomie disponible, le pourcentage exact de la batterie et, en cas de charge, l'heure estimée de fin de charge.</p>
+<p>Notez que l'image du véhicule change selon que le véhicule est en charge ou non.</p>
+</td>
+</tr>
+
+<tr>
+<td>
+<img src="../images/widget_lock_small.png" width="100"/>
+</td>
+<td>
+<p><b>Petite taille</b></p>
+<p>Affiche uniquement le « cercle de batterie » reflétant la capacité de la batterie.</p>
+<p>Notez que l'image du véhicule change selon que le véhicule est en charge ou non.</p>
+</td>
+
+</tr>
+
+<tr >
+<td>
+<img src="../images/widget_lock_inline.png" width="400"/>
+</td>
+<td>
+<p><b>Taille en ligne</b></p>
+<p>Ce widget est disponible pour l'affichage au-dessus de l'heure sur l'écran d'accueil.</p>
+<p>Affiche une version modifiée du « cercle de batterie » avec des icônes pour indiquer la charge / le branchement. Le texte montre l'autonomie disponible et, en cas de charge, l'heure estimée de fin de charge.</p>
+</td>
+</tr>
+
+</table>
+
+----

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,7 @@
 title: Home
 nav_order: 1
 layout: home
+lang: en
 ---
 
 # Hyundai / Kia E-GMP scriptable app for IOS

--- a/docs/pages/automations.md
+++ b/docs/pages/automations.md
@@ -2,6 +2,7 @@
 title: Automations
 layout: home
 nav_order: 6
+lang: en
 ---
 
 # Automations

--- a/docs/pages/control-center.md
+++ b/docs/pages/control-center.md
@@ -2,6 +2,7 @@
 title: Control Center
 layout: home
 nav_order: 6
+lang: en
 ---
 
 # Control Center Support

--- a/docs/pages/faq.md
+++ b/docs/pages/faq.md
@@ -2,6 +2,7 @@
 title: Help
 layout: home
 nav_order: 8
+lang: en
 ---
 
 # Help / FAQ

--- a/docs/pages/features.md
+++ b/docs/pages/features.md
@@ -2,6 +2,7 @@
 title: App Features
 layout: home
 nav_order: 3
+lang: en
 ---
 
 # Bluelink Scriptable feature set

--- a/docs/pages/install.md
+++ b/docs/pages/install.md
@@ -2,6 +2,7 @@
 title: Installation
 layout: home
 nav_order: 4
+lang: en
 ---
 
 # Install Guide

--- a/docs/pages/multi-car.md
+++ b/docs/pages/multi-car.md
@@ -2,6 +2,7 @@
 title: Multi Car
 layout: home
 nav_order: 7
+lang: en
 ---
 
 # Multiple Car Support

--- a/docs/pages/siri.md
+++ b/docs/pages/siri.md
@@ -2,6 +2,7 @@
 title: Siri / Shortcuts
 layout: home
 nav_order: 5
+lang: en
 ---
 
 # Siri Shortcuts Support

--- a/docs/pages/widgets.md
+++ b/docs/pages/widgets.md
@@ -2,6 +2,7 @@
 title: Widgets
 layout: home
 nav_order: 2
+lang: en
 ---
 
 # Widget Support


### PR DESCRIPTION
## Summary

Adds internationalization infrastructure to the documentation site using [jekyll-polyglot](https://github.com/untra/polyglot). When a user switches languages via the header dropdown, the **entire site transforms** — sidebar navigation, page titles, and content all render in the selected language.

### Changes

**Infrastructure:**
- Switch from `github-pages` gem to Jekyll 4 + `jekyll-polyglot` (required since Polyglot is not a whitelisted GitHub Pages plugin)
- Update GitHub Actions workflow (`docs.yml`) for custom Jekyll build with Ruby setup and bundler cache
- SHA-pin all Actions for supply chain security
- Add language dropdown selector in `_includes/header_custom.html`
- Add `lang: en` frontmatter to all 10 English pages
- Configure Polyglot in `_config.yml` (languages: en/fr, exclude assets from localization)

**French translations (10 pages):**
- Sourced from community translation PRs #76–#84 by @verticalpl
- `widgets.md` translated from scratch (no existing PR)
- Pages mirror English file structure in `docs/fr/` with matching permalinks

### How it works
- Polyglot builds the site once per language into separate subfolders (`/` for English, `/fr/` for French)
- Pages are matched across languages by permalink
- Internal links are automatically relativized (French pages link to French pages)
- Missing translations fall back to English

### Adding more languages
1. Create a `docs/<lang>/` directory mirroring the English structure
2. Add `lang: <code>` and matching `permalink:` frontmatter to each page
3. Add the language code to `languages:` in `_config.yml`
4. Update the dropdown labels in `header_custom.html`

Closes the language support request from PR #83.