### PR TITLE
Provide proper otpMethod arg into sendotp API

### DIFF
--- a/src/lib/bluelink-regions/canada.ts
+++ b/src/lib/bluelink-regions/canada.ts
@@ -178,7 +178,7 @@ export class BluelinkCanada extends Bluelink {
     const sendOtpResp = await this.request({
       url: this.apiDomain + 'mfa/sendotp',
       data: JSON.stringify({
-        otpMethod: notifyBySms ? 'S' : 'E',
+        otpMethod: notifyBySms ? 'M' : 'E',
         mfaApiCode: '0107',
         userAccount: otpRequest.email,
         userPhone: notifyBySms ? otpRequest.phone : '',


### PR DESCRIPTION
## Description

The actual `otpMethod` code to send for SMS is 'M' not 'S'.

Verified this by triggering an MFA request using
https://mybluelink.ca/ and recording the browser session

## Details

### selverifmeth API

<img width="1404" height="252" alt="1" src="https://github.com/user-attachments/assets/e25dbc18-2b7d-42f5-91a0-e51eca3a454d" />

### sendotp API

<img width="1408" height="376" alt="2" src="https://github.com/user-attachments/assets/2920a915-f307-4d80-904e-8c4b7846ef23" />

### SMS received

<img width="1206" height="737" alt="3" src="https://github.com/user-attachments/assets/8adf8f7f-e038-4c10-b493-63f48165b2d2" />

### validateotp API

#### Request
<img width="1384" height="300" alt="4" src="https://github.com/user-attachments/assets/8b19db45-ef8a-4925-8670-82e7342e4959" />

#### Response
<img width="2630" height="354" alt="5" src="https://github.com/user-attachments/assets/56cc0264-e7e2-4d3d-97b7-07ab3f4957b1" />
